### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pharaoh",
   "description": "AI assistant framework for sphinx-needs projects: change analysis, traceability, MECE, authoring, verification, and release management",
-  "version": "0.2.0",
+  "version": "1.2.0",
   "author": {
     "name": "useblocks"
   },

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "pharaoh",
       "description": "AI assistant framework for sphinx-needs projects",
-      "version": "0.1.0",
+      "version": "1.2.0",
       "source": "./",
       "author": {
         "name": "useblocks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-05
+
 ### Migration
 
 - `id-conventions.yaml`: rename `id_regex_by_type:` to `id_regex_exceptions:` to


### PR DESCRIPTION
## Summary
- Bump plugin manifest (`.claude-plugin/plugin.json`) from 0.1.0 → 1.2.0
- Bump marketplace manifest (`.github/plugin/marketplace.json`) from 0.1.0 → 1.2.0
- Promote `CHANGELOG.md` Unreleased section to `[1.2.0] - 2026-05-05`

The 1.2.0 changelog covers the atomic-skill chain (16 new skills) introduced since 0.1.0, replacing the retired `pharaoh-author` and `pharaoh-verify` monoliths.

## Test plan
- [x] CI workflow passes on this branch
- [x] After merge, tag `v1.2.0` to trigger the release workflow (`.github/workflows/release.yaml`)
- [x] Confirm GitHub release archive `pharaoh-v1.2.0.zip` is published with the generated changelog